### PR TITLE
Fixed myid for multinode setup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,6 @@ client_port: 2181
 init_limit: 5
 sync_limit: 2
 tick_time: 2000
-zoo_id: 1
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}

--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -1,1 +1,5 @@
-{{ zoo_id }}
+{% for server in zookeeper_hosts %}
+{% if server.host == inventory_hostname %}
+{{ server.id }}
+{% endif %}
+{% endfor %}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -5,11 +5,7 @@ clientPort={{ client_port }}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
 
-{#
-Also consider:
-server.{{server.id}}={{server.host}}:2888:3888
-#}
 
 {% for server in zookeeper_hosts %}
-server.{{loop.index}}={{server.host}}:2888:3888
+server.{{server.id}}={{server.host}}:2888:3888
 {% endfor %}


### PR DESCRIPTION
All host had zoo_id as 1 by default as it used from default template hence all
the zookeeper nodes were not able to work with each other.
This fix will help operators to specify server id for host. This will help
them to configure the multinode zookeeper
Also cleaned up zoo.conf by replacing use of loop.index to use of server.id
for full consistency.
